### PR TITLE
Move to dns sd

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ correct bucket name, you can create the environment with:
 
     # terraform commands from above
 
-    cd ../app-ecs-nodes
+    cd ../infra-dns-discovery
 
     # terraform commands from above
 
     cd ../app-ecs-albs
+
+    # terraform commands from above
+
+    cd ../app-ecs-nodes
 
     # terraform commands from above
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ correct bucket name, you can create the environment with:
 
     $ terraform init -backend-config=../../../environments/dwilson-staging.backend
 
-    $ terraform plan -var-file=./../../environments/dwilson-staging.tfvars
+    $ terraform plan -var-file=../../../environments/dwilson-staging.tfvars
 
-    $ terraform apply -var-file=./../../environments/dwilson-staging.tfvars
+    $ terraform apply -var-file=../../../environments/dwilson-staging.tfvars
 
     cd ../infra-security-groups
 

--- a/terraform/projects/app-ecs-albs/internal-alb.tf
+++ b/terraform/projects/app-ecs-albs/internal-alb.tf
@@ -1,0 +1,91 @@
+variable "internal_service_aliases" {
+  type        = "list"
+  description = "A list of internal aliases that resolve to the internal ALB"
+  default     = [
+    "metrics-nginx",
+    "prometheus-blackbox",
+    "prometheus-server",
+  ]
+}
+
+### Internal ALB
+
+resource "aws_lb" "monitoring_internal_alb" {
+  name               = "${var.stack_name}-int-alb"
+  internal           = true
+  load_balancer_type = "application"
+  security_groups    = ["${data.terraform_remote_state.infra_security_groups.monitoring_int_alb_sg_id}"]
+
+  subnets = [
+    "${element(data.terraform_remote_state.infra_networking.private_subnets, 1)}",
+    "${element(data.terraform_remote_state.infra_networking.private_subnets, 2)}",
+  ]
+
+  tags = "${merge(
+    local.default_tags,
+    var.additional_tags,
+    map("Stackname", "${var.stack_name}"),
+    map("Name", "${var.stack_name}-ecs-monitoring-internal")
+  )}"
+}
+
+### Prometheus server
+
+resource "aws_lb_target_group" "monitoring_internal_prometheus_server_tg" {
+  name     = "${var.stack_name}-int-prom-server-tg"
+  port     = 9090
+  protocol = "HTTP"
+  vpc_id   = "${data.terraform_remote_state.infra_networking.vpc_id}"
+
+  health_check {
+    interval            = "10"
+    path                = "/metrics"
+    matcher             = "200"
+    port                = "9090"
+    protocol            = "HTTP"
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    timeout             = "6"
+  }
+}
+
+resource "aws_lb_listener" "monitoring_internal_prometheus_server" {
+  load_balancer_arn = "${aws_lb.monitoring_internal_alb.arn}"
+  port              = "9090"
+  protocol          = "HTTP"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.monitoring_internal_prometheus_server_tg.arn}"
+    type             = "forward"
+  }
+}
+
+### Prometheus blackbox
+
+### Add DNS Aliases
+# Add all the aliases that should point to the internal load balancer
+
+resource "aws_route53_record" "internal_service_aliases" {
+  count   = "${length(var.internal_service_aliases)}"
+  zone_id = "${data.terraform_remote_state.infra_dns_discovery.private_monitoring_zone_id}"
+  name    = "${element(var.internal_service_aliases, count.index)}.${data.terraform_remote_state.infra_dns_discovery.private_monitoring_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = "${aws_lb.monitoring_internal_alb.dns_name}"
+    zone_id                = "${aws_lb.monitoring_internal_alb.zone_id}"
+    evaluate_target_health = false /* TODO */
+  }
+}
+
+## Outputs
+
+output "monitoring_internal_prometheus_server_tg" {
+  value       = "${aws_lb_target_group.monitoring_internal_prometheus_server_tg.arn}"
+  description = "Prometheus server internal ALB target group"
+}
+
+output "monitoring_internal_dns" {
+  value       = "${aws_lb.monitoring_internal_alb.dns_name}"
+  description = "Internal Monitoring ALB DNS name"
+}

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -83,6 +83,8 @@ data "terraform_remote_state" "infra_security_groups" {
 
 ## Resources
 
+### External ALB
+
 resource "aws_lb" "monitoring_external_alb" {
   name               = "${var.stack_name}-ext-alb"
   internal           = false
@@ -105,7 +107,7 @@ resource "aws_lb" "monitoring_external_alb" {
     local.default_tags,
     var.additional_tags,
     map("Stackname", "${var.stack_name}"),
-    map("Name", "${var.stack_name}-ecs-monitoring")
+    map("Name", "${var.stack_name}-ecs-monitoring-external")
   )}"
 }
 
@@ -143,4 +145,9 @@ resource "aws_lb_listener" "monitoring_external" {
 output "monitoring_external_tg" {
   value       = "${aws_lb_target_group.monitoring_external_tg.arn}"
   description = "External Monitoring ALB target group"
+}
+
+output "monitoring_external_dns" {
+  value       = "${aws_lb.monitoring_external_alb.dns_name}"
+  description = "External Monitoring ALB DNS name"
 }

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -117,7 +117,7 @@ resource "aws_lb_target_group" "monitoring_external_tg" {
 
   health_check {
     interval            = "10"
-    path                = "/"
+    path                = "/health"
     matcher             = "200"
     port                = "80"
     protocol            = "HTTP"

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -81,6 +81,16 @@ data "terraform_remote_state" "infra_security_groups" {
   }
 }
 
+data "terraform_remote_state" "infra_dns_discovery" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "infra-dns-discovery.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
 ## Resources
 
 ### External ALB

--- a/terraform/projects/app-ecs-albs/main.tf
+++ b/terraform/projects/app-ecs-albs/main.tf
@@ -87,7 +87,7 @@ resource "aws_lb" "monitoring_external_alb" {
   name               = "${var.stack_name}-ext-alb"
   internal           = false
   load_balancer_type = "application"
-  security_groups    = ["${data.terraform_remote_state.infra_security_groups.monitoring_external_sg_id}"]
+  security_groups    = ["${data.terraform_remote_state.infra_security_groups.monitoring_ext_alb_sg_id}"]
 
   subnets = [
     "${element(data.terraform_remote_state.infra_networking.public_subnets, 1)}",

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -47,6 +47,10 @@ provider "aws" {
   region  = "${var.aws_region}"
 }
 
+provider "template" {
+  version = "~> 1.0.0"
+}
+
 ## Data sources
 
 data "terraform_remote_state" "infra_networking" {
@@ -75,6 +79,16 @@ data "terraform_remote_state" "app_ecs_albs" {
   config {
     bucket = "${var.remote_state_bucket}"
     key    = "app-ecs-albs.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
+data "terraform_remote_state" "infra_dns_discovery" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "infra-dns-discovery.tfstate"
     region = "${var.aws_region}"
   }
 }

--- a/terraform/projects/app-ecs-services/main.tf
+++ b/terraform/projects/app-ecs-services/main.tf
@@ -59,16 +59,6 @@ data "terraform_remote_state" "infra_networking" {
   }
 }
 
-data "terraform_remote_state" "infra_service_discovery" {
-  backend = "s3"
-
-  config {
-    bucket = "${var.remote_state_bucket}"
-    key    = "infra-service-discovery.tfstate"
-    region = "${var.aws_region}"
-  }
-}
-
 data "terraform_remote_state" "infra_security_groups" {
   backend = "s3"
 

--- a/terraform/projects/app-ecs-services/metrics-nginx.tf
+++ b/terraform/projects/app-ecs-services/metrics-nginx.tf
@@ -1,0 +1,24 @@
+data "template_file" "metrics_nginx_container_definition" {
+  template = "${file("task-definitions/metrics-nginx.json.tpl")}"
+
+  vars {
+    search_domain = "${data.terraform_remote_state.infra_dns_discovery.private_monitoring_domain_name}"
+  }
+}
+
+resource "aws_ecs_task_definition" "metrics_nginx" {
+  family                = "metrics-nginx"
+  container_definitions = "${data.template_file.metrics_nginx_container_definition.rendered}"
+
+  volume {
+    name      = "metrics-nginx"
+    host_path = "/ecs/pulled-config/nginx-metrics-proxy/metrics-proxy"
+  }
+}
+
+resource "aws_ecs_service" "metrics_nginx" {
+  name            = "metrics_nginx"
+  cluster         = "${local.cluster_name}"
+  task_definition = "${aws_ecs_task_definition.metrics_nginx.arn}"
+  desired_count   = 1
+}

--- a/terraform/projects/app-ecs-services/nginx.tf
+++ b/terraform/projects/app-ecs-services/nginx.tf
@@ -1,6 +1,14 @@
+data "template_file" "base_nginx_container_definition" {
+  template = "${file("task-definitions/base-nginx.json.tpl")}"
+
+  vars {
+    search_domain = "${data.terraform_remote_state.infra_dns_discovery.private_monitoring_domain_name}"
+  }
+}
+
 resource "aws_ecs_task_definition" "base_nginx" {
   family                = "nginx"
-  container_definitions = "${file("task-definitions/base-nginx.json")}"
+  container_definitions = "${data.template_file.base_nginx_container_definition.rendered}"
 
   volume {
     name      = "external-config-password"

--- a/terraform/projects/app-ecs-services/prometheus-blackbox.tf
+++ b/terraform/projects/app-ecs-services/prometheus-blackbox.tf
@@ -9,12 +9,4 @@ resource "aws_ecs_service" "prometheus_blackbox" {
   cluster         = "${local.cluster_name}"
   task_definition = "${aws_ecs_task_definition.prometheus_blackbox.arn}"
   desired_count   = 1
-
-  service_registries {
-    registry_arn = "${data.terraform_remote_state.infra_service_discovery.prometheus_blackbox_discovery_arn}"
-  }
-
-  network_configuration {
-    subnets = ["${data.terraform_remote_state.infra_networking.private_subnets}"]
-  }
 }

--- a/terraform/projects/app-ecs-services/prometheus-blackbox.tf
+++ b/terraform/projects/app-ecs-services/prometheus-blackbox.tf
@@ -1,7 +1,14 @@
+data "template_file" "prometheus_blackbox_container_definition" {
+  template = "${file("task-definitions/prometheus-blackbox.json.tpl")}"
+
+  vars {
+    search_domain = "${data.terraform_remote_state.infra_dns_discovery.private_monitoring_domain_name}"
+  }
+}
+
 resource "aws_ecs_task_definition" "prometheus_blackbox" {
   family                = "prometheus-blackbox"
-  network_mode          = "awsvpc"
-  container_definitions = "${file("task-definitions/prometheus-blackbox.json")}"
+  container_definitions = "${data.template_file.prometheus_blackbox_container_definition.rendered}"
 }
 
 resource "aws_ecs_service" "prometheus_blackbox" {

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -1,7 +1,14 @@
+data "template_file" "prometheus_server_container_definition" {
+  template = "${file("task-definitions/prometheus-server.json.tpl")}"
+
+  vars {
+    search_domain = "${data.terraform_remote_state.infra_dns_discovery.private_monitoring_domain_name}"
+  }
+}
+
 resource "aws_ecs_task_definition" "prometheus_server" {
   family                = "prometheus-server"
-  network_mode          = "awsvpc"
-  container_definitions = "${file("task-definitions/prometheus-server.json")}"
+  container_definitions = "${data.template_file.prometheus_server_container_definition.rendered}"
 
   volume {
     name      = "prometheus-config"
@@ -19,4 +26,10 @@ resource "aws_ecs_service" "prometheus_server" {
   cluster         = "${local.cluster_name}"
   task_definition = "${aws_ecs_task_definition.prometheus_server.arn}"
   desired_count   = 1
+
+  load_balancer {
+    target_group_arn = "${data.terraform_remote_state.app_ecs_albs.monitoring_internal_prometheus_server_tg}"
+    container_name   = "prometheus"
+    container_port   = 9090
+  }
 }

--- a/terraform/projects/app-ecs-services/prometheus-service.tf
+++ b/terraform/projects/app-ecs-services/prometheus-service.tf
@@ -19,12 +19,4 @@ resource "aws_ecs_service" "prometheus_server" {
   cluster         = "${local.cluster_name}"
   task_definition = "${aws_ecs_task_definition.prometheus_server.arn}"
   desired_count   = 1
-
-  service_registries {
-    registry_arn = "${data.terraform_remote_state.infra_service_discovery.prometheus_server_discovery_arn}"
-  }
-
-  network_configuration {
-    subnets = ["${data.terraform_remote_state.infra_networking.private_subnets}"]
-  }
 }

--- a/terraform/projects/app-ecs-services/task-definitions/base-nginx.json.tpl
+++ b/terraform/projects/app-ecs-services/task-definitions/base-nginx.json.tpl
@@ -11,6 +11,9 @@
         "hostPort": 80
       }
     ],
+    "dnsSearchDomains": [
+      "${search_domain}"
+    ],
     "mountPoints": [
       {
         "sourceVolume": "external-config-password",

--- a/terraform/projects/app-ecs-services/task-definitions/metrics-nginx.json.tpl
+++ b/terraform/projects/app-ecs-services/task-definitions/metrics-nginx.json.tpl
@@ -1,0 +1,24 @@
+[
+  {
+    "name": "nginx",
+    "image": "nginx",
+    "cpu": 10,
+    "memory": 256,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 8080,
+        "hostPort": 8080
+      }
+    ],
+    "dnsSearchDomains": [
+      "${search_domain}"
+    ],
+    "mountPoints": [
+      {
+        "sourceVolume": "metrics-nginx",
+        "containerPath": "/etc/nginx/conf.d/default.conf"
+      }
+    ]
+  }
+]

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-blackbox.json.tpl
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-blackbox.json.tpl
@@ -10,6 +10,9 @@
         "containerPort": 9115,
         "hostPort": 9115
       }
+    ],
+    "dnsSearchDomains": [
+      "${search_domain}"
     ]
   }
 ]

--- a/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json.tpl
+++ b/terraform/projects/app-ecs-services/task-definitions/prometheus-server.json.tpl
@@ -11,6 +11,9 @@
         "hostPort": 9090
       }
     ],
+    "dnsSearchDomains": [
+      "${search_domain}"
+    ],
     "mountPoints": [
       {
         "sourceVolume": "prometheus-config",

--- a/terraform/projects/infra-dns-discovery/main.tf
+++ b/terraform/projects/infra-dns-discovery/main.tf
@@ -1,0 +1,112 @@
+/**
+* ## Project: infra-dns-discovery
+*
+* Manage the common DNS infrastructure to enable basic DNS discovery
+* and communicaiton between services
+*
+* TODO: once everything is working decide if this should be isolated
+* or in ALB / networking projects instead
+*
+*/
+
+variable "additional_tags" {
+  type        = "map"
+  description = "Stack specific tags to apply"
+  default     = {}
+}
+
+variable "aws_region" {
+  type        = "string"
+  description = "AWS region"
+  default     = "eu-west-1"
+}
+
+variable "remote_state_bucket" {
+  type        = "string"
+  description = "S3 bucket we store our terraform state in"
+  default     = "ecs-monitoring"
+}
+
+variable "remote_state_infra_networking_key_stack" {
+  type        = "string"
+  description = "Override infra-networking remote state path"
+  default     = "infra-security-groups.tfstate"
+}
+
+variable "stack_name" {
+  type        = "string"
+  description = "Unique name for this collection of resources"
+  default     = "ecs-monitoring"
+}
+
+variable "zone_name" {
+  type        = "string"
+  description = "Private zone name for internal communication"
+  default     = "sd.ecs-monitoring.com"
+}
+
+# locals
+# --------------------------------------------------------------
+
+locals {
+  default_tags = {
+    Terraform = "true"
+    Project   = "infra-dns-discovery"
+  }
+}
+
+# Resources
+# --------------------------------------------------------------
+
+## Providers
+
+terraform {
+  required_version = "= 0.11.7"
+
+  backend "s3" {
+    key = "infra-dns-discovery.tfstate"
+  }
+}
+
+provider "aws" {
+  version = "~> 1.17.0"
+  region  = "${var.aws_region}"
+}
+
+## Data sources
+
+data "terraform_remote_state" "infra_networking" {
+  backend = "s3"
+
+  config {
+    bucket = "${var.remote_state_bucket}"
+    key    = "infra-networking.tfstate"
+    region = "${var.aws_region}"
+  }
+}
+
+resource "aws_route53_zone" "private_monitoring" {
+  name = "${var.zone_name}"
+
+  comment = "Terraform managed private zone for service communication"
+  vpc_id  = "${data.terraform_remote_state.infra_networking.vpc_id}"
+
+  tags = "${merge(
+    local.default_tags,
+    var.additional_tags,
+    map("Stackname", "${var.stack_name}"),
+    map("Name", "${var.stack_name}-ecs-monitoring-private")
+  )}"
+}
+
+## Outputs
+
+output "private_monitoring_zone_id" {
+  value       = "${aws_route53_zone.private_monitoring.zone_id}"
+  description = "Private monitoring Route53 zone ID"
+}
+
+output "private_monitoring_domain_name" {
+  value       = "${var.zone_name}"
+  description = "Domain name used for the private Route53 zone"
+}

--- a/terraform/projects/infra-dns-discovery/readme.md
+++ b/terraform/projects/infra-dns-discovery/readme.md
@@ -1,0 +1,28 @@
+## Project: infra-dns-discovery
+
+Manage the common DNS infrastructure to enable basic DNS discovery
+and communicaiton between services
+
+TODO: once everything is working decide if this should be isolated
+or in ALB / networking projects instead
+
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| additional_tags | Stack specific tags to apply | map | `<map>` | no |
+| aws_region | AWS region | string | `eu-west-1` | no |
+| remote_state_bucket | S3 bucket we store our terraform state in | string | `ecs-monitoring` | no |
+| remote_state_infra_networking_key_stack | Override infra-networking remote state path | string | `infra-security-groups.tfstate` | no |
+| stack_name | Unique name for this collection of resources | string | `ecs-monitoring` | no |
+| zone_name | Private zone name for internal communication | string | `sd.ecs-monitoring.com` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| private_monitoring_domain_name | Domain name used for the private Route53 zone |
+| private_monitoring_zone_id | Private monitoring Route53 zone ID |
+

--- a/terraform/projects/infra-networking/main.tf
+++ b/terraform/projects/infra-networking/main.tf
@@ -69,7 +69,8 @@ module "vpc" {
   public_subnets   = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
   database_subnets = ["10.0.201.0/24", "10.0.202.0/24", "10.0.203.0/24"]
 
-  enable_nat_gateway = true
+  enable_nat_gateway   = true
+  enable_dns_hostnames = true
 
   tags = "${merge(
     local.default_tags,


### PR DESCRIPTION
Move away from the AWS ECS Service discovery / autonaming. It's been very awkward to condfigure and keeps hitting ENI limits so for this test environment use basic DNS discovery instead.