### PR TITLE
Add alertmanager to ECS

### DIFF
--- a/terraform/projects/app-ecs-services/alertmanager.tf
+++ b/terraform/projects/app-ecs-services/alertmanager.tf
@@ -1,0 +1,24 @@
+data "template_file" "alertmanager_container_definition" {
+  template = "${file("task-definitions/alertmanager.json.tpl")}"
+
+  vars {
+    search_domain = "${data.terraform_remote_state.infra_dns_discovery.private_monitoring_domain_name}"
+  }
+}
+
+resource "aws_ecs_task_definition" "alertmanager" {
+  family                = "alertmanager"
+  container_definitions = "${data.template_file.alertmanager_container_definition.rendered}"
+
+  volume {
+    name      = "alertmanager-config"
+    host_path = "/ecs/pulled-config/alertmanager/alertmanager.yml"
+  }
+}
+
+resource "aws_ecs_service" "alertmanager" {
+  name            = "alertmanager"
+  cluster         = "${local.cluster_name}"
+  task_definition = "${aws_ecs_task_definition.alertmanager.arn}"
+  desired_count   = 1
+}

--- a/terraform/projects/app-ecs-services/task-definitions/alertmanager.json.tpl
+++ b/terraform/projects/app-ecs-services/task-definitions/alertmanager.json.tpl
@@ -1,0 +1,28 @@
+[
+  {
+    "name": "alertmanager",
+    "image": "prom/alertmanager",
+    "cpu": 10,
+    "memory": 256,
+    "essential": true,
+    "portMappings": [
+      {
+        "containerPort": 9093,
+        "hostPort": 9093
+      }
+    ],
+    "dnsSearchDomains": [
+      "${search_domain}"
+    ],
+    "command": [
+      "--log.level=debug",
+      "--config.file=/alertmanager.yml"
+    ],
+    "mountPoints": [
+      {
+        "sourceVolume": "alertmanager-config",
+        "containerPath": "/alertmanager.yml"
+      }
+    ]
+  }
+]

--- a/terraform/projects/infra-security-groups/main.tf
+++ b/terraform/projects/infra-security-groups/main.tf
@@ -208,6 +208,18 @@ resource "aws_security_group_rule" "monitoring_internal_sg_ingress_int-alb_prome
   description = "Nginx auth container to load balance prometheus"
 }
 
+resource "aws_security_group_rule" "monitoring_internal_sg_ingress_loopback_alertmanager" {
+  type      = "ingress"
+  from_port = 9093
+  to_port   = 9093
+  protocol  = "tcp"
+
+  security_group_id        = "${aws_security_group.monitoring_internal_sg.id}"
+  source_security_group_id = "${aws_security_group.monitoring_internal_sg.id}"
+
+  description = "ECS instances can connect to themselves to access AlertManager"
+}
+
 resource "aws_security_group_rule" "monitoring_internal_sg_ingress_int-alb_prometheus-blackbox" {
   type      = "ingress"
   from_port = 9115


### PR DESCRIPTION
Prometheus doesn't like to connect to alertmanager via a loadbalancer so find them via service discovery.